### PR TITLE
Switch Dependabot scans from daily to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,9 @@ updates:
 - package-ecosystem: maven
   directory: "/"
   schedule:
-    interval: daily
+    interval: monthly
   open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: /
   schedule:
-    interval: daily
+    interval: monthly


### PR DESCRIPTION
This component rarely changes so it does not make sense to accept every incremental update.